### PR TITLE
Reduce number of "replace" invocations

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -39,18 +39,11 @@ function handleText(textNode)
 {
 	var v = textNode.nodeValue;
 
-	v = v.replace(/\bAWS Lambda\b/g, "AWS Common Gateway Interface");
-	v = v.replace(/\bAWS lambda\b/g, "AWS Common Gateway Interface");
-	v = v.replace(/\baws Lambda\b/g, "AWS Common Gateway Interface");
-	v = v.replace(/\baws lambda\b/g, "AWS Common Gateway Interface");
+	v = v.replace(/\bAWS Lambda\b/ig, "AWS Common Gateway Interface");
 
-	v = v.replace(/\bServerless\b/g, "cgi-bin");
-	v = v.replace(/\bserverless\b/g, "cgi-bin");
+	v = v.replace(/\bServerless\b/ig, "cgi-bin");
 
-	v = v.replace(/\bcgi-bin architecture\b/g, "Common Gateway Interface architecture");
-	v = v.replace(/\bcgi-bin architectures\b/g, "Common Gateway Interface architecture");
-	v = v.replace(/\bcgi-bin Architecture\b/g, "Common Gateway Interface architecture");
-	v = v.replace(/\bcgi-bin Architectures\b/g, "Common Gateway Interface architecture");
+	v = v.replace(/\bcgi-bin architectures?\b/ig, "Common Gateway Interface architecture");
 	
 	textNode.nodeValue = v;
 }


### PR DESCRIPTION
This PR makes the following changes to reduce the number of invocations of `.replace()` and therefore the overall number of times we parse the document.

* Make regex match case insensitive.  This has the added benefit of matching e.g.: `AwS lAmBdA` as well as the other iterations.
* Make `s` optional in `architecture` so both `architecture` and `architectures` match.